### PR TITLE
fix: import styles on front-end and during SSR to avoid FOUC

### DIFF
--- a/gatsby-browser.js
+++ b/gatsby-browser.js
@@ -1,40 +1,10 @@
 import React from 'react';
 import { Provider } from 'react-redux';
-import { injectGlobal } from 'emotion';
 
 import createStore from './src/state/createStore';
 
-injectGlobal`
-body {
-  margin: 0;
-  color: white;
-  word-wrap: break-word;
-  box-sizing: border-box;
-  background: #333;
-}
-a {
-  color: white;
-}
-a:active,
-a:hover {
-  outline-width: 0;
-  color: white;
-  text-decoration: underline;
-}
-html {
-  box-sizing: border-box;
-  overflow-y: scroll;
-}
-* {
-  box-sizing: inherit;
-}
-*:before {
-  box-sizing: inherit;
-}
-*:after {
-  box-sizing: inherit;
-}
-`;
+// Import global styles here
+import './src/utils/global-styles';
 
 const store = createStore();
 

--- a/gatsby-ssr.js
+++ b/gatsby-ssr.js
@@ -4,6 +4,9 @@ import { renderToString } from 'react-dom/server';
 
 import createStore from './src/state/createStore';
 
+// Import global styles here
+import './src/utils/global-styles';
+
 export const replaceRenderer = ({ bodyComponent, replaceBodyHTMLString }) => {
   const store = createStore();
 

--- a/src/utils/global-styles.js
+++ b/src/utils/global-styles.js
@@ -1,0 +1,33 @@
+import { injectGlobal } from 'emotion';
+
+injectGlobal`
+  body {
+    margin: 0;
+    color: white;
+    word-wrap: break-word;
+    box-sizing: border-box;
+    background: #333;
+  }
+  a {
+    color: white;
+  }
+  a:active,
+  a:hover {
+    outline-width: 0;
+    color: white;
+    text-decoration: underline;
+  }
+  html {
+    box-sizing: border-box;
+    overflow-y: scroll;
+  }
+  * {
+    box-sizing: inherit;
+  }
+  *:before {
+    box-sizing: inherit;
+  }
+  *:after {
+    box-sizing: inherit;
+  }
+`;


### PR DESCRIPTION
I haven't been able to test this because I'm missing the `.env` values, but here's what I _think_ was happening:

- global styles were loaded in `gatsby-browser.js`, which means they were only applied client-side — that's the FOUC
- by importing them in both the browser and SSR steps, it _should_ result in the global styles being inlined
- because Emotion hashes styles, this _should not_ result in duplicate styles

Another solution, if this doesn't work as expected, would be to include the global styles in `src/components/layout.js`. You'll get the FOUC during development, but it should be gone in production.

Let me know if this doesn't work as expected!